### PR TITLE
[epublibre] Add alternative unblock site

### DIFF
--- a/src/Jackett.Common/Indexers/EpubLibre.cs
+++ b/src/Jackett.Common/Indexers/EpubLibre.cs
@@ -43,6 +43,11 @@ namespace Jackett.Common.Indexers
             {"11", "portugués"},
             {"12", "esperanto"}
         };
+        
+        public override string[] AlternativeSiteLinks { get; protected set; } = {
+            "https://epublibre.org/",
+            "https://epublibre.unblockit.lat/"
+        };
 
         public EpubLibre(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)
             : base(id: "epublibre",


### PR DESCRIPTION
epublibre is blocked in some ISPs. I add the alternative unblock site to be able to use it.